### PR TITLE
Feature/add prioirty by name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: docker/build-push-action@v4
         with:
           push: true
-          tags: ghcr.io/postalserver/postal:ci-${{ github.sha }}
+          tags: ghcr.io/querateam/postal:ci-${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           target: ci
@@ -52,12 +52,12 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - run: docker-compose pull
+      - run: docker compose pull
         env:
-          POSTAL_IMAGE: ghcr.io/postalserver/postal:ci-${{ github.sha }}
-      - run: docker-compose run postal sh -c 'bundle exec rspec'
+          POSTAL_IMAGE: ghcr.io/querateam/postal:ci-${{ github.sha }}
+      - run: docker compose run postal sh -c 'bundle exec rspec'
         env:
-          POSTAL_IMAGE: ghcr.io/postalserver/postal:ci-${{ github.sha }}
+          POSTAL_IMAGE: ghcr.io/querateam/postal:ci-${{ github.sha }}
 
   release-branch:
     name: Release (branch)
@@ -80,7 +80,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - id: info
         run: |
-          IMAGE=ghcr.io/postalserver/postal
+          IMAGE=ghcr.io/querateam/postal
 
           REF="${GITHUB_REF#refs/heads/}"
           if [ -z "$REF" ]; then exit 1; fi
@@ -126,8 +126,8 @@ jobs:
         with:
           push: true
           tags: |
-            ghcr.io/postalserver/postal:stable
-            ghcr.io/postalserver/postal:${{ needs.release-please.outputs.version }}
+            ghcr.io/querateam/postal:stable
+            ghcr.io/querateam/postal:${{ needs.release-please.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           target: full

--- a/app/lib/worker/jobs/process_queued_messages_job.rb
+++ b/app/lib/worker/jobs/process_queued_messages_job.rb
@@ -40,12 +40,15 @@ module Worker
       end
 
       # Obtain a queued message from the database for processing
-      #
+      # order by the server name suffix (numerically) descending, then by ID ascending
+      # example server names: server-1, server-2, server-9 -> order: server-9, server-2, server-1
       # @return [void]
       def lock_message_for_processing
-        QueuedMessage.where(ip_address_id: [nil, @ip_addresses])
+        QueuedMessage.joins(:server)
+                     .where(ip_address_id: [nil, @ip_addresses])
                      .where(locked_by: nil, locked_at: nil)
                      .ready_with_delayed_retry
+                     .order(Arel.sql("CAST(SUBSTRING_INDEX(servers.name, '-', -1) AS UNSIGNED) DESC, queued_messages.id ASC"))
                      .limit(1)
                      .update_all(locked_by: @locker, locked_at: @lock_time)
       end


### PR DESCRIPTION
Description
This change updates the message locking logic to prioritize queued messages based on the numeric suffix of the server name (higher numbers first). Among messages on the same server, the oldest message is selected first.

Example
If there are messages from server-10, server-5, and server-2, the system will first lock a message from server-10, then from server-5, and finally from server-2.